### PR TITLE
feat: upgrading minimum cloudformation-cli version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         "cloudformation-cli>=0.1.11,<0.2",
         # "aws-lambda-builders>=1.0,<2.0",
-        "zipfile38>=0.0.2,<0.2",
+        "zipfile38>=0.0.3,<0.2",
     ],
     entry_points={
         "rpdk.v1.languages": [

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     zip_safe=True,
     python_requires=">=3.6",
     install_requires=[
-        "cloudformation-cli>=0.1.10,<0.2",
+        "cloudformation-cli>=0.1.11,<0.2",
         # "aws-lambda-builders>=1.0,<2.0",
         "zipfile38>=0.0.2,<0.2",
     ],


### PR DESCRIPTION
`cloudformation-cli` versions older than [`0.1.11`](https://github.com/aws-cloudformation/cloudformation-cli/releases/tag/v0.1.11) are being deprecated